### PR TITLE
fixup! arm64: dts: VIM1S: fix memory size sync from s4_s905y4_ap222_d…

### DIFF
--- a/arch/arm64/boot/dts/amlogic/kvim1s.dts
+++ b/arch/arm64/boot/dts/amlogic/kvim1s.dts
@@ -93,14 +93,14 @@
 		ion_fb_reserved:linux,ion-fb {
 			compatible = "shared-dma-pool";
 			reusable;
-			size = <0x0 0x10000000>;
+			size = <0x0 0x0>;
 			alignment = <0x0 0x400000>;
 		};
 		dmaheap_fb_reserved:heap-fb {
 			compatible = "shared-dma-pool";
 			reusable;
 			/* 1080p STB androidT size 56M */
-			size = <0x0 0x0>;
+			size = <0x0 0x3800000>;
 			alignment = <0x0 0x400000>;
 		};
 		dmaheap_cma_reserved:heap-gfx {


### PR DESCRIPTION
…ebian.dts

Change-Id: I1c2cadb35e1dcb4b5ac0a308bd443ea95f042a76