### PR TITLE
arm64: dts: VIM3L: fix the MIPI + HDMI 4K display screen problem

### DIFF
--- a/arch/arm64/boot/dts/amlogic/mesonsm1_drm_dual_disp.dtsi
+++ b/arch/arm64/boot/dts/amlogic/mesonsm1_drm_dual_disp.dtsi
@@ -75,7 +75,7 @@
 
 &drm_vpu {
 	assigned-clocks = <&clkc CLKID_VPU_CLKC_MUX>;
-	assigned-clock-rates = <200000000>;
+	assigned-clock-rates = <667000000>;
 	connectors_dev: port@1 {
 		drm_to_lcd0: endpoint@2 {
 			reg = <2>;


### PR DESCRIPTION
Change-Id: I80ff554f377602ba736a074c11e4d734c5022761